### PR TITLE
Add ability to reference other cells while editing

### DIFF
--- a/lib/DataCell.js
+++ b/lib/DataCell.js
@@ -325,7 +325,7 @@ var DataCell = (function (_PureComponent) {
             cell: cell,
             row: row,
             col: col,
-            value: this.state.value,
+            value: this.state.value || initialData(this.props),
             onChange: this.handleChange,
             onCommit: this.handleCommit,
             onRevert: this.handleRevert,

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -464,12 +464,14 @@ var DataSheet = (function (_PureComponent) {
           start = _getState4.start,
           editing = _getState4.editing;
 
-        var data = this.props.data;
+        var _props4 = this.props,
+          data = _props4.data,
+          isSelectingWhileEditing = _props4.isSelectingWhileEditing;
 
         var isEditing = editing && !isEmpty(editing);
         var currentCell = data[start.i] && data[start.i][start.j];
 
-        if (isEditing && !commit) {
+        if (isEditing && !isSelectingWhileEditing && !commit) {
           return false;
         }
         var hasComponent = currentCell && currentCell.component;
@@ -509,6 +511,8 @@ var DataSheet = (function (_PureComponent) {
           end = _getState5.end,
           editing = _getState5.editing;
 
+        var isSelectingWhileEditing = this.props.isSelectingWhileEditing;
+
         var isEditing = editing && !isEmpty(editing);
         var noCellsSelected = !start || isEmpty(start);
         var ctrlKeyPressed = e.ctrlKey || e.metaKey;
@@ -530,12 +534,18 @@ var DataSheet = (function (_PureComponent) {
           return true;
         }
 
-        if (!isEditing) {
+        if (!isEditing || isSelectingWhileEditing) {
           this.handleKeyboardCellMovement(e);
           if (deleteKeysPressed) {
             e.preventDefault();
             this.clearSelectedCells(start, end);
           } else if (currentCell && !currentCell.readOnly) {
+            if (isSelectingWhileEditing) {
+              // Do nothing if other cell is being edited.
+              // The next branches are needed to start edit mode one way or another,
+              // and we don't need it if we are currently refernecing to other cells
+              return;
+            }
             if (enterKeyPressed) {
               this._setState({ editing: start, clear: {}, forceEdit: true });
               e.preventDefault();
@@ -576,10 +586,10 @@ var DataSheet = (function (_PureComponent) {
       value: function clearSelectedCells(start, end) {
         var _this2 = this;
 
-        var _props4 = this.props,
-          data = _props4.data,
-          onCellsChanged = _props4.onCellsChanged,
-          onChange = _props4.onChange;
+        var _props5 = this.props,
+          data = _props5.data,
+          onCellsChanged = _props5.onCellsChanged,
+          onChange = _props5.onChange;
 
         var cells = this.getSelectedCells(data, start, end)
           .filter(function (cell) {
@@ -611,10 +621,13 @@ var DataSheet = (function (_PureComponent) {
     {
       key: 'updateLocationSingleCell',
       value: function updateLocationSingleCell(location) {
+        var isSelectingWhileEditing = this.props.isSelectingWhileEditing;
+
+        var editing = isSelectingWhileEditing ? this.state.editing : {};
         this._setState({
           start: location,
           end: location,
-          editing: {},
+          editing: editing,
         });
       },
     },
@@ -625,17 +638,20 @@ var DataSheet = (function (_PureComponent) {
           start = _getState6.start,
           end = _getState6.end;
 
-        var data = this.props.data;
+        var _props6 = this.props,
+          data = _props6.data,
+          isSelectingWhileEditing = _props6.isSelectingWhileEditing;
 
         var oldStartLocation = { i: start.i, j: start.j };
         var newEndLocation = {
           i: end.i + offsets.i,
           j: Math.min(data[0].length - 1, Math.max(0, end.j + offsets.j)),
         };
+        var editing = isSelectingWhileEditing ? this.state.editing : {};
         this._setState({
           start: oldStartLocation,
           end: newEndLocation,
-          editing: {},
+          editing: editing,
         });
       },
     },
@@ -762,7 +778,9 @@ var DataSheet = (function (_PureComponent) {
           return;
         }
         var editing = this.state.editing;
-        var data = this.props.data;
+        var _props7 = this.props,
+          data = _props7.data,
+          isSelectingWhileEditing = _props7.isSelectingWhileEditing;
 
         var isEditing = !isEmpty(editing);
         if (isEditing) {
@@ -790,6 +808,29 @@ var DataSheet = (function (_PureComponent) {
               _this3.dgDom && _this3.dgDom.focus({ preventScroll: true });
             }, 1);
           }
+          if (isSelectingWhileEditing) {
+            e.preventDefault();
+            var _func = function _func() {};
+            if (keyCode === _keys.ESCAPE_KEY) {
+              _func = function _func() {
+                _this3.onRevert();
+                _this3.props.onSelectWhileEditingAbort &&
+                  _this3.props.onSelectWhileEditingAbort();
+              };
+            } else if (keyCode === _keys.ENTER_KEY) {
+              _func = function _func() {
+                _this3.props.onSelectWhileEditingComplete &&
+                  _this3.props.onSelectWhileEditingComplete();
+              };
+            }
+            setTimeout(function () {
+              _this3.dgDom && _this3.dgDom.focus({ preventScroll: true });
+              _this3.setState(function () {
+                return { editing: {} };
+              });
+              _func();
+            }, 1);
+          }
         }
       },
     },
@@ -806,7 +847,7 @@ var DataSheet = (function (_PureComponent) {
       key: 'onDoubleClick',
       value: function onDoubleClick(i, j) {
         var cell = this.props.data[i][j];
-        if (!cell.readOnly) {
+        if (!cell.readOnly && !this.props.isSelectingWhileEditing) {
           this._setState({
             editing: { i: i, j: j },
             forceEdit: true,
@@ -822,20 +863,42 @@ var DataSheet = (function (_PureComponent) {
           !isEmpty(this.state.editing) &&
           this.state.editing.i === i &&
           this.state.editing.j === j;
+        var isNowEditingOtherCell =
+          !isEmpty(this.state.editing) &&
+          (this.state.editing.i !== i || this.state.editing.j !== j);
         var editing =
-          isEmpty(this.state.editing) ||
-          this.state.editing.i !== i ||
-          this.state.editing.j !== j
+          (isEmpty(this.state.editing) ||
+            this.state.editing.i !== i ||
+            this.state.editing.j !== j) &&
+          !this.props.canSelectWhileEditing
             ? {}
             : this.state.editing;
 
-        this._setState({
-          selecting: !isNowEditingSameCell,
-          start: e.shiftKey ? this.getState().start : { i: i, j: j },
-          end: { i: i, j: j },
-          editing: editing,
-          forceEdit: !!isNowEditingSameCell,
-        });
+        if (this.props.isSelectingWhileEditing && isNowEditingSameCell) {
+          // stop editing and selection if we click on cell that initiated cell selection
+          this._setState({
+            selecting: false,
+            start: { i: i, j: j },
+            end: { i: i, j: j },
+            editing: {},
+            forceEdit: false,
+          });
+          this.props.onSelectWhileEditingAbort &&
+            this.props.onSelectWhileEditingAbort();
+        } else {
+          this._setState({
+            selecting: !isNowEditingSameCell,
+            start: e.shiftKey ? this.getState().start : { i: i, j: j },
+            end: { i: i, j: j },
+            editing: editing,
+            forceEdit: !!isNowEditingSameCell,
+          });
+
+          if (isNowEditingOtherCell && this.props.canSelectWhileEditing) {
+            this.props.onSelectWhileEditingStart &&
+              this.props.onSelectWhileEditingStart();
+          }
+        }
 
         var ua = window.navigator.userAgent;
         var isIE = /MSIE|Trident/.test(ua);
@@ -873,10 +936,10 @@ var DataSheet = (function (_PureComponent) {
     {
       key: 'onChange',
       value: function onChange(row, col, value) {
-        var _props5 = this.props,
-          onChange = _props5.onChange,
-          onCellsChanged = _props5.onCellsChanged,
-          data = _props5.data;
+        var _props8 = this.props,
+          onChange = _props8.onChange,
+          onCellsChanged = _props8.onCellsChanged,
+          data = _props8.data;
 
         if (onCellsChanged) {
           onCellsChanged([
@@ -947,19 +1010,19 @@ var DataSheet = (function (_PureComponent) {
       value: function render() {
         var _this4 = this;
 
-        var _props6 = this.props,
-          SheetRenderer = _props6.sheetRenderer,
-          RowRenderer = _props6.rowRenderer,
-          cellRenderer = _props6.cellRenderer,
-          dataRenderer = _props6.dataRenderer,
-          valueRenderer = _props6.valueRenderer,
-          dataEditor = _props6.dataEditor,
-          valueViewer = _props6.valueViewer,
-          attributesRenderer = _props6.attributesRenderer,
-          className = _props6.className,
-          overflow = _props6.overflow,
-          data = _props6.data,
-          keyFn = _props6.keyFn;
+        var _props9 = this.props,
+          SheetRenderer = _props9.sheetRenderer,
+          RowRenderer = _props9.rowRenderer,
+          cellRenderer = _props9.cellRenderer,
+          dataRenderer = _props9.dataRenderer,
+          valueRenderer = _props9.valueRenderer,
+          dataEditor = _props9.dataEditor,
+          valueViewer = _props9.valueViewer,
+          attributesRenderer = _props9.attributesRenderer,
+          className = _props9.className,
+          overflow = _props9.overflow,
+          data = _props9.data,
+          keyFn = _props9.keyFn;
         var forceEdit = this.state.forceEdit;
 
         return _react2.default.createElement(
@@ -1068,6 +1131,11 @@ DataSheet.propTypes = {
   keyFn: _propTypes2.default.func,
   handleCopy: _propTypes2.default.func,
   editModeChanged: _propTypes2.default.func,
+  canSelectWhileEditing: _propTypes2.default.bool,
+  isSelectingWhileEditing: _propTypes2.default.bool,
+  onSelectWhileEditingStart: _propTypes2.default.func,
+  onSelectWhileEditingComplete: _propTypes2.default.func,
+  onSelectWhileEditingAbort: _propTypes2.default.func,
 };
 
 DataSheet.defaultProps = {
@@ -1076,4 +1144,6 @@ DataSheet.defaultProps = {
   cellRenderer: _Cell2.default,
   valueViewer: _ValueViewer2.default,
   dataEditor: _DataEditor2.default,
+  canSelectWhileEditing: false,
+  isSelectingWhileEditing: false,
 };

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -888,16 +888,12 @@ var DataSheet = (function (_PureComponent) {
           this.props.onSelectWhileEditingAbort &&
             this.props.onSelectWhileEditingAbort();
         } else {
-          console.log('} else {');
-          console.log('isNowEditingSameCell', isNowEditingSameCell);
-          console.log('editing', editing);
-          console.log('isNowEditingOtherCell', isNowEditingOtherCell);
-          console.log(
-            'this.props.canSelectWhileEditing',
-            this.props.canSelectWhileEditing,
-          );
-
           if (isNowEditingOtherCell && this.props.canSelectWhileEditing) {
+            // we need to run two separate callbacks for upper component:
+            // onSelectWhileEditingStart and onSelect. Both of them update state and it causes
+            // conflicts between them.
+            // The only solution that worked is wrapping the second callback in setTimeout.
+
             this.props.onSelectWhileEditingStart &&
               this.props.onSelectWhileEditingStart();
 

--- a/lib/DataSheet.js
+++ b/lib/DataSheet.js
@@ -859,6 +859,8 @@ var DataSheet = (function (_PureComponent) {
     {
       key: 'onMouseDown',
       value: function onMouseDown(i, j, e) {
+        var _this4 = this;
+
         var isNowEditingSameCell =
           !isEmpty(this.state.editing) &&
           this.state.editing.i === i &&
@@ -886,17 +888,36 @@ var DataSheet = (function (_PureComponent) {
           this.props.onSelectWhileEditingAbort &&
             this.props.onSelectWhileEditingAbort();
         } else {
-          this._setState({
-            selecting: !isNowEditingSameCell,
-            start: e.shiftKey ? this.getState().start : { i: i, j: j },
-            end: { i: i, j: j },
-            editing: editing,
-            forceEdit: !!isNowEditingSameCell,
-          });
+          console.log('} else {');
+          console.log('isNowEditingSameCell', isNowEditingSameCell);
+          console.log('editing', editing);
+          console.log('isNowEditingOtherCell', isNowEditingOtherCell);
+          console.log(
+            'this.props.canSelectWhileEditing',
+            this.props.canSelectWhileEditing,
+          );
 
           if (isNowEditingOtherCell && this.props.canSelectWhileEditing) {
             this.props.onSelectWhileEditingStart &&
               this.props.onSelectWhileEditingStart();
+
+            setTimeout(function () {
+              _this4._setState({
+                selecting: !isNowEditingSameCell,
+                start: e.shiftKey ? _this4.getState().start : { i: i, j: j },
+                end: { i: i, j: j },
+                editing: editing,
+                forceEdit: !!isNowEditingSameCell,
+              });
+            }, 0);
+          } else {
+            this._setState({
+              selecting: !isNowEditingSameCell,
+              start: e.shiftKey ? this.getState().start : { i: i, j: j },
+              end: { i: i, j: j },
+              editing: editing,
+              forceEdit: !!isNowEditingSameCell,
+            });
           }
         }
 
@@ -1008,7 +1029,7 @@ var DataSheet = (function (_PureComponent) {
     {
       key: 'render',
       value: function render() {
-        var _this4 = this;
+        var _this5 = this;
 
         var _props9 = this.props,
           SheetRenderer = _props9.sheetRenderer,
@@ -1029,7 +1050,7 @@ var DataSheet = (function (_PureComponent) {
           'span',
           {
             ref: function ref(r) {
-              _this4.dgDom = r;
+              _this5.dgDom = r;
             },
             tabIndex: '0',
             className: 'data-grid-container',
@@ -1050,7 +1071,7 @@ var DataSheet = (function (_PureComponent) {
                 RowRenderer,
                 { key: keyFn ? keyFn(i) : i, row: i, cells: row },
                 row.map(function (cell, j) {
-                  var isEditing = _this4.isEditing(i, j);
+                  var isEditing = _this5.isEditing(i, j);
                   return _react2.default.createElement(
                     _DataCell2.default,
                     _extends(
@@ -1060,17 +1081,17 @@ var DataSheet = (function (_PureComponent) {
                         col: j,
                         cell: cell,
                         forceEdit: false,
-                        onMouseDown: _this4.onMouseDown,
-                        onMouseOver: _this4.onMouseOver,
-                        onDoubleClick: _this4.onDoubleClick,
-                        onContextMenu: _this4.onContextMenu,
-                        onChange: _this4.onChange,
-                        onRevert: _this4.onRevert,
-                        onNavigate: _this4.handleKeyboardCellMovement,
-                        onKey: _this4.handleKey,
-                        selected: _this4.isSelected(i, j),
+                        onMouseDown: _this5.onMouseDown,
+                        onMouseOver: _this5.onMouseOver,
+                        onDoubleClick: _this5.onDoubleClick,
+                        onContextMenu: _this5.onContextMenu,
+                        onChange: _this5.onChange,
+                        onRevert: _this5.onRevert,
+                        onNavigate: _this5.handleKeyboardCellMovement,
+                        onKey: _this5.handleKey,
+                        selected: _this5.isSelected(i, j),
                         editing: isEditing,
-                        clearing: _this4.isClearing(i, j),
+                        clearing: _this5.isClearing(i, j),
                         attributesRenderer: attributesRenderer,
                         cellRenderer: cellRenderer,
                         valueRenderer: valueRenderer,

--- a/src/DataCell.js
+++ b/src/DataCell.js
@@ -165,7 +165,7 @@ export default class DataCell extends PureComponent {
           cell={cell}
           row={row}
           col={col}
-          value={this.state.value}
+          value={this.state.value || initialData(this.props)}
           onChange={this.handleChange}
           onCommit={this.handleCommit}
           onRevert={this.handleRevert}

--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -601,17 +601,32 @@ export default class DataSheet extends PureComponent {
       this.props.onSelectWhileEditingAbort &&
         this.props.onSelectWhileEditingAbort();
     } else {
-      this._setState({
-        selecting: !isNowEditingSameCell,
-        start: e.shiftKey ? this.getState().start : { i, j },
-        end: { i, j },
-        editing: editing,
-        forceEdit: !!isNowEditingSameCell,
-      });
-
       if (isNowEditingOtherCell && this.props.canSelectWhileEditing) {
+        // we need to run two separate callbacks for upper component:
+        // onSelectWhileEditingStart and onSelect. Both of them update state and it causes
+        // conflicts between them.
+        // The only solution that worked is wrapping the second callback in setTimeout.
+
         this.props.onSelectWhileEditingStart &&
           this.props.onSelectWhileEditingStart();
+
+        setTimeout(() => {
+          this._setState({
+            selecting: !isNowEditingSameCell,
+            start: e.shiftKey ? this.getState().start : { i, j },
+            end: { i, j },
+            editing: editing,
+            forceEdit: !!isNowEditingSameCell,
+          });
+        }, 0);
+      } else {
+        this._setState({
+          selecting: !isNowEditingSameCell,
+          start: e.shiftKey ? this.getState().start : { i, j },
+          end: { i, j },
+          editing: editing,
+          forceEdit: !!isNowEditingSameCell,
+        });
       }
     }
 

--- a/types/react-datasheet.d.ts
+++ b/types/react-datasheet.d.ts
@@ -1,327 +1,275 @@
-import {
-  Component,
-  ReactNode,
-  KeyboardEventHandler,
-  MouseEventHandler,
-} from 'react';
+import { Component, ReactNode, KeyboardEventHandler, MouseEventHandler } from "react";
 
 declare namespace ReactDataSheet {
-  /** The cell object is what gets passed to the callbacks and events, and contains the basic information about what to show in each cell. You should extend this interface to build a place to store your data.
-   * @example
-   * interface GridElement extends ReactDataSheet.Cell<GridElement> {
-   *      value: number | string | null;
-   * }
-   */
-  export interface Cell<T extends Cell<T, V>, V = string> {
-    /** Optional function or React Component to render a custom editor. Overrides grid-level dataEditor option. Default: undefined. */
-    dataEditor?: DataEditor<T, V>;
-    /** Additional class names for cells. Default: undefined. */
-    className?: string | undefined;
-    /** Insert a react element or JSX to this field. This will render on edit mode. Default: undefined. */
-    component?: JSX.Element;
-    /** The colSpan of the cell's td element. Default: 1 */
-    colSpan?: number;
-    /** If true, renders what's in component at all times, even when not in edit mode. Default: false. */
-    forceComponent?: boolean;
-    /** By default, each cell is given the key of col number and row number. This would override that key. Default: undefined. */
-    key?: string | undefined;
-    /** Makes cell unselectable and read only. Default: false. */
-    disableEvents?: boolean;
-    /** How to render overflow text. Overrides grid-level overflow option. Default: undefined. */
-    overflow?: 'wrap' | 'nowrap' | 'clip';
-    /** If true, the cell will never go in edit mode. Default: false. */
-    readOnly?: boolean;
-    /** The rowSpan of the cell's td element. Default: 1. */
-    rowSpan?: number;
-    /** Optional function or React Component to customize the way the value for this cell is displayed. Overrides grid-level valueViewer option. Default: undefined. */
-    valueViewer?: ValueViewer<T, V>;
-    /** Sets the cell's td width using a style attribute. Number is interpreted as pixels, strings are used as-is. Note: This will only work if the table does not have a set width. Default: undefined. */
-    width?: number | string;
-  }
+    /** The cell object is what gets passed to the callbacks and events, and contains the basic information about what to show in each cell. You should extend this interface to build a place to store your data.
+     * @example
+     * interface GridElement extends ReactDataSheet.Cell<GridElement> {
+     *      value: number | string | null;
+     * }
+     */
+    export interface Cell<T extends Cell<T, V>, V = string> {
+        /** Optional function or React Component to render a custom editor. Overrides grid-level dataEditor option. Default: undefined. */
+        dataEditor?: DataEditor<T, V>
+        /** Additional class names for cells. Default: undefined. */
+        className?: string | undefined;
+        /** Insert a react element or JSX to this field. This will render on edit mode. Default: undefined. */
+        component?: JSX.Element;
+        /** The colSpan of the cell's td element. Default: 1 */
+        colSpan?: number;
+        /** If true, renders what's in component at all times, even when not in edit mode. Default: false. */
+        forceComponent?: boolean;
+        /** By default, each cell is given the key of col number and row number. This would override that key. Default: undefined. */
+        key?: string | undefined;
+        /** Makes cell unselectable and read only. Default: false. */
+        disableEvents?: boolean;
+        /** How to render overflow text. Overrides grid-level overflow option. Default: undefined. */
+        overflow?: 'wrap' | 'nowrap' | 'clip';
+        /** If true, the cell will never go in edit mode. Default: false. */
+        readOnly?: boolean;
+        /** The rowSpan of the cell's td element. Default: 1. */
+        rowSpan?: number;
+        /** Optional function or React Component to customize the way the value for this cell is displayed. Overrides grid-level valueViewer option. Default: undefined. */
+        valueViewer?: ValueViewer<T, V>;
+        /** Sets the cell's td width using a style attribute. Number is interpreted as pixels, strings are used as-is. Note: This will only work if the table does not have a set width. Default: undefined. */
+        width?: number | string;
+    }
 
-  export interface Location {
-    i: number;
-    j: number;
-  }
-  export interface Selection {
-    start: Location;
-    end: Location;
-  }
-  /** Properties of the ReactDataSheet component. */
-  export interface DataSheetProps<T extends Cell<T, V>, V = string> {
-    /** Optional function to add attributes to the rendered cell element. It should return an object with properties corresponding to the name and vales of the attributes you wish to add. */
-    attributesRenderer?: AttributesRenderer<T, V>;
-    /** Optional function or React Component to render each cell element. The default renders a td element. */
-    cellRenderer?: CellRenderer<T, V>;
-    className?: string;
-    /** Array of rows and each row should contain the cell objects to display. */
-    data: T[][];
-    /** Optional: Avoid Datasheet to listen for clicks on the page */
-    disablePageClick?: boolean;
-    /** Optional function or React Component to render a custom editor. Affects every cell in the sheet. Affects every cell in the sheet. See cell options to override individual cells. */
-    dataEditor?: DataEditor<T, V>;
-    /** Method to render the underlying value of the cell function(cell, i, j). This data is visible once in edit mode. */
-    dataRenderer?: DataRenderer<T, V>;
-    /** Method to handle copying from cell */
-    handleCopy?: HandleCopyFunction<T, V>;
-    /** onCellsChanged handler: function(arrayOfChanges[, arrayOfAdditions]) {}, where changes is an array of objects of the shape {cell, row, col, value}. */
-    onCellsChanged?: CellsChangedHandler<T, V>;
-    /** Context menu handler : function(event, cell, i, j). */
-    onContextMenu?: ContextMenuHandler<T, V>;
-    /** Grid default for how to render overflow text in cells. */
-    overflow?: 'wrap' | 'nowrap' | 'clip';
-    /** Optional function or React Component to render each row element. The default renders a <tr> element. */
-    rowRenderer?: RowRenderer<T, V>;
-    /** If set, the function will be called with the raw clipboard data. It should return an array of arrays of strings. This is useful for when the clipboard may have data with irregular field or line delimiters. If not set, rows will be split with line breaks and cells with tabs. */
-    parsePaste?: PasteParser;
-    /** Optional function or React Component to render the main sheet element. The default renders a table element. */
-    sheetRenderer?: SheetRenderer<T, V>;
-    /** Method to render the value of the cell function(cell, i, j). This is visible by default. */
-    valueRenderer: ValueRenderer<T, V>;
-    /** Optional function or React Component to customize the way the value for each cell in the sheet is displayed. Affects every cell in the sheet. See cell options to override individual cells. */
-    valueViewer?: ValueViewer<T, V>;
-    /** Optional. Passing a selection format will make the selection controlled, pass a null for usual behaviour**/
-    selected?: Selection | null;
-    /** Optional. Calls the function whenever the user changes selection**/
-    onSelect?: (selection: Selection) => void;
-    /** Optional. Function to set row key. **/
-    keyFn?: (row: number) => string | number;
-    /** Optional: Function that can decide whether navigating to the indicated cell is possible. */
-    isCellNavigable?: (
-      cell: T,
-      row: number,
-      col: number,
-      jumpNext: boolean,
-    ) => boolean;
-    /** Optional: Is called when datasheet changes edit mode. */
-    editModeChanged?: (inEditMode: boolean) => void;
-    /** Determines if user can perform a selection without losing focus of edited cell. */
-    canSelectWhileEditing?: boolean;
-    /** Determines if user is performing a selection without losing focus of edited cell. */
-    isSelectingWhileEditing?: boolean;
+    export interface Location {
+        i: number,
+        j: number
+    }
+    export interface Selection {
+        start: Location,
+        end: Location
+    }
+    /** Properties of the ReactDataSheet component. */
+    export interface DataSheetProps<T extends Cell<T, V>, V = string> {
+        /** Optional function to add attributes to the rendered cell element. It should return an object with properties corresponding to the name and vales of the attributes you wish to add. */
+        attributesRenderer?: AttributesRenderer<T, V>;
+        /** Optional function or React Component to render each cell element. The default renders a td element. */
+        cellRenderer?: CellRenderer<T, V>;
+        className?: string;
+        /** Array of rows and each row should contain the cell objects to display. */
+        data: T[][];
+        /** Optional: Avoid Datasheet to listen for clicks on the page */
+        disablePageClick?: boolean;
+        /** Optional function or React Component to render a custom editor. Affects every cell in the sheet. Affects every cell in the sheet. See cell options to override individual cells. */
+        dataEditor?: DataEditor<T, V>;
+        /** Method to render the underlying value of the cell function(cell, i, j). This data is visible once in edit mode. */
+        dataRenderer?: DataRenderer<T, V>;
+        /** Method to handle copying from cell */
+        handleCopy?: HandleCopyFunction<T, V>;
+        /** onCellsChanged handler: function(arrayOfChanges[, arrayOfAdditions]) {}, where changes is an array of objects of the shape {cell, row, col, value}. */
+        onCellsChanged?: CellsChangedHandler<T, V>;
+        /** Context menu handler : function(event, cell, i, j). */
+        onContextMenu?: ContextMenuHandler<T, V>;
+        /** Grid default for how to render overflow text in cells. */
+        overflow?: 'wrap' | 'nowrap' | 'clip';
+        /** Optional function or React Component to render each row element. The default renders a <tr> element. */
+        rowRenderer?: RowRenderer<T, V>;
+        /** If set, the function will be called with the raw clipboard data. It should return an array of arrays of strings. This is useful for when the clipboard may have data with irregular field or line delimiters. If not set, rows will be split with line breaks and cells with tabs. */
+        parsePaste?: PasteParser;
+        /** Optional function or React Component to render the main sheet element. The default renders a table element. */
+        sheetRenderer?: SheetRenderer<T, V>;
+        /** Method to render the value of the cell function(cell, i, j). This is visible by default. */
+        valueRenderer: ValueRenderer<T, V>;
+        /** Optional function or React Component to customize the way the value for each cell in the sheet is displayed. Affects every cell in the sheet. See cell options to override individual cells. */
+        valueViewer?: ValueViewer<T, V>;
+        /** Optional. Passing a selection format will make the selection controlled, pass a null for usual behaviour**/
+        selected?: Selection | null;
+        /** Optional. Calls the function whenever the user changes selection**/
+        onSelect?: (selection: Selection) => void;
+        /** Optional. Function to set row key. **/
+        keyFn?: (row: number) => string | number;
+        /** Optional: Function that can decide whether navigating to the indicated cell is possible. */
+        isCellNavigable?: (cell: T, row: number, col: number, jumpNext: boolean) => boolean;
+        /** Optional: Is called when datasheet changes edit mode. */
+        editModeChanged?: (inEditMode: boolean) => void;
+        /** Determines if user can perform a selection without losing focus of edited cell. */
+        canSelectWhileEditing?: boolean;
+        /** Determines if user is performing a selection without losing focus of edited cell. */
+        isSelectingWhileEditing?: boolean;
 
-    onSelectWhileEditingStart?: () => void;
+        onSelectWhileEditingStart?: () => void;
 
-    onSelectWhileEditingComplete?: () => void;
+        onSelectWhileEditingComplete?: () => void;
 
-    onSelectWhileEditingAbort?: () => void;
-  }
+        onSelectWhileEditingAbort?: () => void;
+    }
 
-  /** A function to process the raw clipboard data. It should return an array of arrays of strings. This is useful for when the clipboard may have data with irregular field or line delimiters. If not set, rows will be split with line breaks and cells with tabs. To wire it up pass your function to the parsePaste property of the ReactDataSheet component. */
-  export type PasteParser = (pastedString: string) => string[][];
+    /** A function to process the raw clipboard data. It should return an array of arrays of strings. This is useful for when the clipboard may have data with irregular field or line delimiters. If not set, rows will be split with line breaks and cells with tabs. To wire it up pass your function to the parsePaste property of the ReactDataSheet component. */
+    export type PasteParser = (pastedString: string) => string[][];
 
-  /** A function to render the value of the cell function(cell, i, j). This is visible by default. To wire it up, pass your function to the valueRenderer property of the ReactDataSheet component. */
-  export type ValueRenderer<T extends Cell<T, V>, V = string> = (
-    cell: T,
-    row: number,
-    col: number,
-  ) => string | number | null | void;
+    /** A function to render the value of the cell function(cell, i, j). This is visible by default. To wire it up, pass your function to the valueRenderer property of the ReactDataSheet component. */
+    export type ValueRenderer<T extends Cell<T, V>, V = string> = (cell: T, row: number, col: number) => string | number | null | void;
 
-  /** A function to render the underlying value of the cell. This data is visible once in edit mode.  To wire it up, pass your function to the dataRenderer property of the ReactDataSheet component. */
-  export type DataRenderer<T extends Cell<T, V>, V = string> = (
-    cell: T,
-    row: number,
-    col: number,
-  ) => string | number | null | void;
+    /** A function to render the underlying value of the cell. This data is visible once in edit mode.  To wire it up, pass your function to the dataRenderer property of the ReactDataSheet component. */
+    export type DataRenderer<T extends Cell<T, V>, V = string> = (cell: T, row: number, col: number) => string | number | null | void;
 
-  /** A function to add attributes to the rendered cell element. It should return an object with properties corresponding to the name and vales of the attributes you wish to add. To wire it up, pass your function to the attributesRenderer property of the ReactDataSheet component. */
-  export type AttributesRenderer<T extends Cell<T, V>, V = string> = (
-    cell: T,
-    row: number,
-    col: number,
-  ) => {};
+    /** A function to add attributes to the rendered cell element. It should return an object with properties corresponding to the name and vales of the attributes you wish to add. To wire it up, pass your function to the attributesRenderer property of the ReactDataSheet component. */
+    export type AttributesRenderer<T extends Cell<T, V>, V = string> = (cell: T, row: number, col: number) => {};
 
-  /** The properties that will be passed to the SheetRenderer component or function. */
-  export interface SheetRendererProps<T extends Cell<T, V>, V = string> {
-    /** The same data array as from main ReactDataSheet component */
-    data: T[][];
-    /** Classes to apply to your top-level element. You can add to these, but your should not overwrite or omit them unless you want to implement your own CSS also. */
-    className: string;
-    /** The regular react props.children. You must render {props.children} within your custom renderer or you won't see your rows and cells. */
-    children: ReactNode;
-  }
+    /** The properties that will be passed to the SheetRenderer component or function. */
+    export interface SheetRendererProps<T extends Cell<T, V>, V = string> {
+        /** The same data array as from main ReactDataSheet component */
+        data: T[][];
+        /** Classes to apply to your top-level element. You can add to these, but your should not overwrite or omit them unless you want to implement your own CSS also. */
+        className: string;
+        /** The regular react props.children. You must render {props.children} within your custom renderer or you won't see your rows and cells. */
+        children: ReactNode;
+    }
 
-  /** Optional function or React Component to render the main sheet element. The default renders a table element. To wire it up, pass your function to the sheetRenderer property of the ReactDataSheet component. */
-  export type SheetRenderer<T extends Cell<T, V>, V = string> =
-    | React.ComponentClass<SheetRendererProps<T, V>>
-    | React.SFC<SheetRendererProps<T, V>>;
+    /** Optional function or React Component to render the main sheet element. The default renders a table element. To wire it up, pass your function to the sheetRenderer property of the ReactDataSheet component. */
+    export type SheetRenderer<T extends Cell<T, V>, V = string> = React.ComponentClass<SheetRendererProps<T, V>> | React.SFC<SheetRendererProps<T, V>>;
 
-  /** The properties that will be passed to the RowRenderer component or function. */
-  export interface RowRendererProps<T extends Cell<T, V>, V = string> {
-    /** The current row index */
-    row: number;
-    /** The cells in the current row */
-    cells: T[];
-    /** The regular react props.children. You must render {props.children} within your custom renderer or you won't see your cells. */
-    children: ReactNode;
-  }
+    /** The properties that will be passed to the RowRenderer component or function. */
+    export interface RowRendererProps<T extends Cell<T, V>, V = string> {
+        /** The current row index */
+        row: number;
+        /** The cells in the current row */
+        cells: T[];
+        /** The regular react props.children. You must render {props.children} within your custom renderer or you won't see your cells. */
+        children: ReactNode;
+    }
 
-  /** Optional function or React Component to render each row element. The default renders a tr element. To wire it up, pass your function to the rowRenderer property of the ReactDataSheet component. */
-  export type RowRenderer<T extends Cell<T, V>, V = string> =
-    | React.ComponentClass<RowRendererProps<T, V>>
-    | React.SFC<RowRendererProps<T, V>>;
+    /** Optional function or React Component to render each row element. The default renders a tr element. To wire it up, pass your function to the rowRenderer property of the ReactDataSheet component. */
+    export type RowRenderer<T extends Cell<T, V>, V = string> = React.ComponentClass<RowRendererProps<T, V>> | React.SFC<RowRendererProps<T, V>>;
 
-  /** The arguments that will be passed to the first parameter of the onCellsChanged handler function. These represent all the changes _inside_ the bounds of the existing grid. The first generic parameter (required) indicates the type of the cell property, and the second generic parameter (default: string) indicates the type of the value property. */
-  export type CellsChangedArgs<T extends Cell<T, V>, V = string> = {
-    /** the original cell object you provided in the data property. This may be null */
-    cell: T | null;
-    /** row index of changed cell */
-    row: number;
-    /** column index of changed cell */
-    col: number;
-    /** The new cell value. This is usually a string, but a custom editor may provide any type of value. */
-    value: V | null;
-  }[];
+    /** The arguments that will be passed to the first parameter of the onCellsChanged handler function. These represent all the changes _inside_ the bounds of the existing grid. The first generic parameter (required) indicates the type of the cell property, and the second generic parameter (default: string) indicates the type of the value property. */
+    export type CellsChangedArgs<T extends Cell<T, V>, V = string> = {
+        /** the original cell object you provided in the data property. This may be null */
+        cell: T | null;
+        /** row index of changed cell */
+        row: number;
+        /** column index of changed cell */
+        col: number;
+        /** The new cell value. This is usually a string, but a custom editor may provide any type of value. */
+        value: V | null;
+    }[];
 
-  /** The arguments that will be passed to the second parameter of the onCellsChanged handler function. These represent all the changes _outside_ the bounds of the existing grid. The  generic parameter (default: string) indicates the type of the value property. */
-  export type CellAdditionsArgs<V = string> = {
-    row: number;
-    col: number;
-    value: V | null;
-  }[];
+    /** The arguments that will be passed to the second parameter of the onCellsChanged handler function. These represent all the changes _outside_ the bounds of the existing grid. The  generic parameter (default: string) indicates the type of the value property. */
+    export type CellAdditionsArgs<V = string> = {
+        row: number;
+        col: number;
+        value: V | null;
+    }[];
 
-  /** onCellsChanged handler: function(arrayOfChanges[, arrayOfAdditions]) {}, where changes is an array of objects of the shape {cell, row, col, value}. To wire it up, pass your function to the onCellsChanged property of the ReactDataSheet component. */
-  export type CellsChangedHandler<T extends Cell<T, V>, V = string> = (
-    arrayOfChanges: CellsChangedArgs<T, V>,
-    arrayOfAdditions?: CellAdditionsArgs<V>,
-  ) => void;
+    /** onCellsChanged handler: function(arrayOfChanges[, arrayOfAdditions]) {}, where changes is an array of objects of the shape {cell, row, col, value}. To wire it up, pass your function to the onCellsChanged property of the ReactDataSheet component. */
+    export type CellsChangedHandler<T extends Cell<T, V>, V = string> = (arrayOfChanges: CellsChangedArgs<T, V>, arrayOfAdditions?: CellAdditionsArgs<V>) => void;
 
-  /** Context menu handler : function(event, cell, i, j). To wire it up, pass your function to the onContextMenu property of the ReactDataSheet component. */
-  export type ContextMenuHandler<T extends Cell<T, V>, V = string> = (
-    event: MouseEvent,
-    cell: T,
-    row: number,
-    col: number,
-  ) => void;
+    /** Context menu handler : function(event, cell, i, j). To wire it up, pass your function to the onContextMenu property of the ReactDataSheet component. */
+    export type ContextMenuHandler<T extends Cell<T, V>, V = string> = (event: MouseEvent, cell: T, row : number, col: number) => void;
 
-  /* Props available for handleCopy */
-  export interface HandleCopyProps<T extends Cell<T, V>, V = string> {
-    event: Event;
-    dataRenderer: DataRenderer<T, V>;
-    valueRenderer: ValueRenderer<T, V>;
-    data: T[][];
-    start: Location;
-    end: Location;
-    range: (start: number, end: number) => [];
-  }
+    /* Props available for handleCopy */
+    export interface HandleCopyProps<T extends Cell<T, V>, V = string> {
+        event: Event;
+        dataRenderer: DataRenderer<T, V>;
+        valueRenderer: ValueRenderer<T, V>;
+        data: T[][];
+        start: Location;
+        end: Location;
+        range: (start: number, end: number) => [];
+    }
 
-  export type HandleCopyFunction<T extends Cell<T, V>, V = string> = (
-    props: HandleCopyProps<T, V>,
-  ) => void;
+    export type HandleCopyFunction<T extends Cell<T, V>, V = string> = (props: HandleCopyProps<T, V>) => void;
 
-  /** The properties that will be passed to the CellRenderer component or function. */
-  export interface CellRendererProps<T extends Cell<T, V>, V = string> {
-    /** The current row index */
-    row: number;
-    /** The current column index */
-    col: number;
-    /** The cell's raw data structure */
-    cell: T;
-    /** Classes to apply to your cell element. You can add to these, but your should not overwrite or omit them unless you want to implement your own CSS also. */
-    className: string;
-    /** Generated styles that you should apply to your cell element. This may be null or undefined. */
-    style: object | null | undefined;
-    /** Is the cell currently selected */
-    selected: boolean;
-    /** Is the cell currently being edited */
-    editing: boolean;
-    /** Was the cell recently updated */
-    updated: boolean;
-    /** As for the main ReactDataSheet component */
-    attributesRenderer: AttributesRenderer<T, V>;
-    /** Event handler: important for cell selection behavior */
-    onMouseDown: MouseEventHandler<HTMLElement>;
-    /** Event handler: important for cell selection behavior */
-    onMouseOver: MouseEventHandler<HTMLElement>;
-    /** Event handler: important for editing */
-    onDoubleClick: MouseEventHandler<HTMLElement>;
-    /** Event handler: to launch default content-menu handling. You can safely ignore this handler if you want to provide your own content menu handling. */
-    onContextMenu: MouseEventHandler<HTMLElement>;
-    /** Event handler: important for cell selection behavior */
-    onKeyUp: KeyboardEventHandler<HTMLElement>;
-    /** The regular react props.children. You must render {props.children} within your custom renderer or you won't your cell's data. */
-    children: ReactNode;
-  }
+    /** The properties that will be passed to the CellRenderer component or function. */
+    export interface CellRendererProps<T extends Cell<T, V>, V = string> {
+        /** The current row index */
+        row: number;
+        /** The current column index */
+        col: number;
+        /** The cell's raw data structure */
+        cell: T;
+        /** Classes to apply to your cell element. You can add to these, but your should not overwrite or omit them unless you want to implement your own CSS also. */
+        className: string;
+        /** Generated styles that you should apply to your cell element. This may be null or undefined. */
+        style: object | null | undefined;
+        /** Is the cell currently selected */
+        selected: boolean;
+        /** Is the cell currently being edited */
+        editing: boolean;
+        /** Was the cell recently updated */
+        updated: boolean;
+        /** As for the main ReactDataSheet component */
+        attributesRenderer: AttributesRenderer<T, V>;
+        /** Event handler: important for cell selection behavior */
+        onMouseDown: MouseEventHandler<HTMLElement>;
+        /** Event handler: important for cell selection behavior */
+        onMouseOver: MouseEventHandler<HTMLElement>;
+        /** Event handler: important for editing */
+        onDoubleClick: MouseEventHandler<HTMLElement>;
+        /** Event handler: to launch default content-menu handling. You can safely ignore this handler if you want to provide your own content menu handling. */
+        onContextMenu: MouseEventHandler<HTMLElement>;
+        /** Event handler: important for cell selection behavior */
+        onKeyUp: KeyboardEventHandler<HTMLElement>;
+        /** The regular react props.children. You must render {props.children} within your custom renderer or you won't your cell's data. */
+        children: ReactNode;
+    }
 
-  /** A function or React Component to render each cell element. The default renders a td element. To wire it up, pass it to the cellRenderer property of the ReactDataSheet component.  */
-  export type CellRenderer<T extends Cell<T, V>, V = string> =
-    | React.ComponentClass<CellRendererProps<T, V>>
-    | React.SFC<CellRendererProps<T, V>>;
+    /** A function or React Component to render each cell element. The default renders a td element. To wire it up, pass it to the cellRenderer property of the ReactDataSheet component.  */
+    export type CellRenderer<T extends Cell<T, V>, V = string> = React.ComponentClass<CellRendererProps<T, V>> | React.SFC<CellRendererProps<T, V>>;
 
-  /** The properties that will be passed to the CellRenderer component or function. */
-  export interface ValueViewerProps<T extends Cell<T, V>, V = string> {
-    /** The result of the valueRenderer function */
-    value: string | number | null;
-    /** The current row index */
-    row: number;
-    /** The current column index */
-    col: number;
-    /** The cell's raw data structure */
-    cell: T;
-  }
+    /** The properties that will be passed to the CellRenderer component or function. */
+    export interface ValueViewerProps<T extends Cell<T, V>, V = string> {
+        /** The result of the valueRenderer function */
+        value: string | number | null;
+        /** The current row index */
+        row: number;
+        /** The current column index */
+        col: number;    
+        /** The cell's raw data structure */
+        cell: T;
+    }
 
-  /** Optional function or React Component to customize the way the value for each cell in the sheet is displayed. If it is passed to the valueViewer property of the ReactDataSheet component, it affects every cell in the sheet. Different editors can also be passed to the valueViewer property of each Cell to control each cell separately. */
-  export type ValueViewer<T extends Cell<T, V>, V = string> =
-    | React.ComponentClass<ValueViewerProps<T, V>>
-    | React.SFC<ValueViewerProps<T, V>>;
+    /** Optional function or React Component to customize the way the value for each cell in the sheet is displayed. If it is passed to the valueViewer property of the ReactDataSheet component, it affects every cell in the sheet. Different editors can also be passed to the valueViewer property of each Cell to control each cell separately. */
+    export type ValueViewer<T extends Cell<T, V>, V = string> = React.ComponentClass<ValueViewerProps<T, V>> | React.SFC<ValueViewerProps<T, V>>;
 
-  /** The properties that will be passed to the DataEditor component or function. */
-  export interface DataEditorProps<T, V = string> {
-    /** The result of the dataRenderer (or valueRenderer if none) */
-    value: string | number | null;
-    /** The current row index */
-    row: number;
-    /** The current column index */
-    col: number;
-    /** The cell's raw data structure */
-    cell: T;
-    /** A callback for when the user changes the value during editing (for example, each time they type a character into an input). onChange does not indicate the final edited value. It works just like a controlled component in a form. */
-    onChange: (newValue: V) => void;
-    /** An event handler that you can call to use default React-DataSheet keyboard handling to signal reverting an ongoing edit (Escape key) or completing an edit (Enter or Tab). For most editors based on an input element this will probably work. However, if this keyboard handling is unsuitable for your editor you can trigger these changes explicitly using the onCommit and onRevert callbacks. */
-    onKeyDown: React.KeyboardEventHandler<HTMLElement>;
-    /** function (newValue, [event]) {} A callback to indicate that editing is over, here is the final value. If you pass a KeyboardEvent as the second argument, React-DataSheet will perform default navigation for you (for example, going down to the next row if you hit the enter key). You actually don't need to use onCommit if the default keyboard handling is good enough for you. */
-    onCommit: (newValue: V, event?: React.KeyboardEvent<HTMLElement>) => void;
-    /** function () {} A no-args callback that you can use to indicate that you want to cancel ongoing edits. As with onCommit, you don't need to worry about this if the default keyboard handling works for your editor. */
-    onRevert: () => void;
-  }
+    /** The properties that will be passed to the DataEditor component or function. */
+    export interface DataEditorProps<T, V = string> {
+        /** The result of the dataRenderer (or valueRenderer if none) */
+        value: string | number | null;
+        /** The current row index */
+        row: number;
+        /** The current column index */
+        col: number;
+        /** The cell's raw data structure */
+        cell: T;
+        /** A callback for when the user changes the value during editing (for example, each time they type a character into an input). onChange does not indicate the final edited value. It works just like a controlled component in a form. */
+        onChange: (newValue: V) => void;
+        /** An event handler that you can call to use default React-DataSheet keyboard handling to signal reverting an ongoing edit (Escape key) or completing an edit (Enter or Tab). For most editors based on an input element this will probably work. However, if this keyboard handling is unsuitable for your editor you can trigger these changes explicitly using the onCommit and onRevert callbacks. */
+        onKeyDown: React.KeyboardEventHandler<HTMLElement>;
+        /** function (newValue, [event]) {} A callback to indicate that editing is over, here is the final value. If you pass a KeyboardEvent as the second argument, React-DataSheet will perform default navigation for you (for example, going down to the next row if you hit the enter key). You actually don't need to use onCommit if the default keyboard handling is good enough for you. */
+        onCommit: (newValue: V, event?: React.KeyboardEvent<HTMLElement>) => void;
+        /** function () {} A no-args callback that you can use to indicate that you want to cancel ongoing edits. As with onCommit, you don't need to worry about this if the default keyboard handling works for your editor. */
+        onRevert: () => void;
+    }
 
-  /** A function or React Component to render a custom editor. If it is passed to the dataEditor property of the ReactDataSheet component, it affects every cell in the sheet. Different editors can also be passed to the dataEditor property of each Cell to control each cell separately. */
-  export type DataEditor<T extends Cell<T, V>, V = string> =
-    | React.ComponentClass<DataEditorProps<T, V>>
-    | React.SFC<DataEditorProps<T, V>>;
+    /** A function or React Component to render a custom editor. If it is passed to the dataEditor property of the ReactDataSheet component, it affects every cell in the sheet. Different editors can also be passed to the dataEditor property of each Cell to control each cell separately. */
+    export type DataEditor<T extends Cell<T, V>, V = string> = React.ComponentClass<DataEditorProps<T, V>> | React.SFC<DataEditorProps<T, V>>;
 
-  export interface CellReference {
-    row: number;
-    col: number;
-  }
+    export interface CellReference {
+        row: number;
+        col: number;
+    }
 
-  export interface DataSheetState {
-    start?: CellReference;
-    end?: CellReference;
-    selecting?: boolean;
-    forceEdit?: boolean;
-    editing?: CellReference;
-    clear?: CellReference;
-    dragging?: boolean;
-  }
+    export interface DataSheetState {
+        start?: CellReference;
+        end?: CellReference;
+        selecting?: boolean;
+        forceEdit?: boolean;
+        editing?: CellReference;
+        clear?: CellReference;
+        dragging?: boolean;
+    }
 }
 
-declare class ReactDataSheet<
-  T extends ReactDataSheet.Cell<T, V>,
-  V = string,
-> extends Component<
-  ReactDataSheet.DataSheetProps<T, V>,
-  ReactDataSheet.DataSheetState
-> {
-  getSelectedCells: (
-    data: T[][],
-    start: ReactDataSheet.CellReference,
-    end: ReactDataSheet.CellReference,
-  ) => { cell: T; row: number; col: number }[];
-  onMouseOver(i: number, j: number): void;
-  handleCut(e: ClipboardEvent): void;
-  handleCopy(e: ClipboardEvent): void;
-  handlePaste(e: ClipboardEvent): void;
+declare class ReactDataSheet<T extends ReactDataSheet.Cell<T, V>, V = string> extends Component<ReactDataSheet.DataSheetProps<T, V>, ReactDataSheet.DataSheetState> {
+    getSelectedCells: (data: T[][], start: ReactDataSheet.CellReference, end: ReactDataSheet.CellReference) => {cell: T, row: number, col: number}[];
+    onMouseOver(i: number, j: number): void;
+    handleCut(e: ClipboardEvent): void;
+    handleCopy(e: ClipboardEvent): void;
+    handlePaste(e: ClipboardEvent): void;
 }
 
 export default ReactDataSheet;

--- a/types/react-datasheet.d.ts
+++ b/types/react-datasheet.d.ts
@@ -1,260 +1,327 @@
-import { Component, ReactNode, KeyboardEventHandler, MouseEventHandler } from "react";
+import {
+  Component,
+  ReactNode,
+  KeyboardEventHandler,
+  MouseEventHandler,
+} from 'react';
 
 declare namespace ReactDataSheet {
-    /** The cell object is what gets passed to the callbacks and events, and contains the basic information about what to show in each cell. You should extend this interface to build a place to store your data.
-     * @example
-     * interface GridElement extends ReactDataSheet.Cell<GridElement> {
-     *      value: number | string | null;
-     * }
-     */
-    export interface Cell<T extends Cell<T, V>, V = string> {
-        /** Optional function or React Component to render a custom editor. Overrides grid-level dataEditor option. Default: undefined. */
-        dataEditor?: DataEditor<T, V>
-        /** Additional class names for cells. Default: undefined. */
-        className?: string | undefined;
-        /** Insert a react element or JSX to this field. This will render on edit mode. Default: undefined. */
-        component?: JSX.Element;
-        /** The colSpan of the cell's td element. Default: 1 */
-        colSpan?: number;
-        /** If true, renders what's in component at all times, even when not in edit mode. Default: false. */
-        forceComponent?: boolean;
-        /** By default, each cell is given the key of col number and row number. This would override that key. Default: undefined. */
-        key?: string | undefined;
-        /** Makes cell unselectable and read only. Default: false. */
-        disableEvents?: boolean;
-        /** How to render overflow text. Overrides grid-level overflow option. Default: undefined. */
-        overflow?: 'wrap' | 'nowrap' | 'clip';
-        /** If true, the cell will never go in edit mode. Default: false. */
-        readOnly?: boolean;
-        /** The rowSpan of the cell's td element. Default: 1. */
-        rowSpan?: number;
-        /** Optional function or React Component to customize the way the value for this cell is displayed. Overrides grid-level valueViewer option. Default: undefined. */
-        valueViewer?: ValueViewer<T, V>;
-        /** Sets the cell's td width using a style attribute. Number is interpreted as pixels, strings are used as-is. Note: This will only work if the table does not have a set width. Default: undefined. */
-        width?: number | string;
-    }
+  /** The cell object is what gets passed to the callbacks and events, and contains the basic information about what to show in each cell. You should extend this interface to build a place to store your data.
+   * @example
+   * interface GridElement extends ReactDataSheet.Cell<GridElement> {
+   *      value: number | string | null;
+   * }
+   */
+  export interface Cell<T extends Cell<T, V>, V = string> {
+    /** Optional function or React Component to render a custom editor. Overrides grid-level dataEditor option. Default: undefined. */
+    dataEditor?: DataEditor<T, V>;
+    /** Additional class names for cells. Default: undefined. */
+    className?: string | undefined;
+    /** Insert a react element or JSX to this field. This will render on edit mode. Default: undefined. */
+    component?: JSX.Element;
+    /** The colSpan of the cell's td element. Default: 1 */
+    colSpan?: number;
+    /** If true, renders what's in component at all times, even when not in edit mode. Default: false. */
+    forceComponent?: boolean;
+    /** By default, each cell is given the key of col number and row number. This would override that key. Default: undefined. */
+    key?: string | undefined;
+    /** Makes cell unselectable and read only. Default: false. */
+    disableEvents?: boolean;
+    /** How to render overflow text. Overrides grid-level overflow option. Default: undefined. */
+    overflow?: 'wrap' | 'nowrap' | 'clip';
+    /** If true, the cell will never go in edit mode. Default: false. */
+    readOnly?: boolean;
+    /** The rowSpan of the cell's td element. Default: 1. */
+    rowSpan?: number;
+    /** Optional function or React Component to customize the way the value for this cell is displayed. Overrides grid-level valueViewer option. Default: undefined. */
+    valueViewer?: ValueViewer<T, V>;
+    /** Sets the cell's td width using a style attribute. Number is interpreted as pixels, strings are used as-is. Note: This will only work if the table does not have a set width. Default: undefined. */
+    width?: number | string;
+  }
 
-    export interface Location {
-        i: number,
-        j: number
-    }
-    export interface Selection {
-        start: Location,
-        end: Location
-    }
-    /** Properties of the ReactDataSheet component. */
-    export interface DataSheetProps<T extends Cell<T, V>, V = string> {
-        /** Optional function to add attributes to the rendered cell element. It should return an object with properties corresponding to the name and vales of the attributes you wish to add. */
-        attributesRenderer?: AttributesRenderer<T, V>;
-        /** Optional function or React Component to render each cell element. The default renders a td element. */
-        cellRenderer?: CellRenderer<T, V>;
-        className?: string;
-        /** Array of rows and each row should contain the cell objects to display. */
-        data: T[][];
-        /** Optional: Avoid Datasheet to listen for clicks on the page */
-        disablePageClick?: boolean;
-        /** Optional function or React Component to render a custom editor. Affects every cell in the sheet. Affects every cell in the sheet. See cell options to override individual cells. */
-        dataEditor?: DataEditor<T, V>;
-        /** Method to render the underlying value of the cell function(cell, i, j). This data is visible once in edit mode. */
-        dataRenderer?: DataRenderer<T, V>;
-        /** Method to handle copying from cell */
-        handleCopy?: HandleCopyFunction<T, V>;
-        /** onCellsChanged handler: function(arrayOfChanges[, arrayOfAdditions]) {}, where changes is an array of objects of the shape {cell, row, col, value}. */
-        onCellsChanged?: CellsChangedHandler<T, V>;
-        /** Context menu handler : function(event, cell, i, j). */
-        onContextMenu?: ContextMenuHandler<T, V>;
-        /** Grid default for how to render overflow text in cells. */
-        overflow?: 'wrap' | 'nowrap' | 'clip';
-        /** Optional function or React Component to render each row element. The default renders a <tr> element. */
-        rowRenderer?: RowRenderer<T, V>;
-        /** If set, the function will be called with the raw clipboard data. It should return an array of arrays of strings. This is useful for when the clipboard may have data with irregular field or line delimiters. If not set, rows will be split with line breaks and cells with tabs. */
-        parsePaste?: PasteParser;
-        /** Optional function or React Component to render the main sheet element. The default renders a table element. */
-        sheetRenderer?: SheetRenderer<T, V>;
-        /** Method to render the value of the cell function(cell, i, j). This is visible by default. */
-        valueRenderer: ValueRenderer<T, V>;
-        /** Optional function or React Component to customize the way the value for each cell in the sheet is displayed. Affects every cell in the sheet. See cell options to override individual cells. */
-        valueViewer?: ValueViewer<T, V>;
-        /** Optional. Passing a selection format will make the selection controlled, pass a null for usual behaviour**/
-        selected?: Selection | null;
-        /** Optional. Calls the function whenever the user changes selection**/
-        onSelect?: (selection: Selection) => void;
-        /** Optional. Function to set row key. **/
-        keyFn?: (row: number) => string | number;
-        /** Optional: Function that can decide whether navigating to the indicated cell is possible. */
-        isCellNavigable?: (cell: T, row: number, col: number, jumpNext: boolean) => boolean;
-        /** Optional: Is called when datasheet changes edit mode. */
-        editModeChanged?: (inEditMode: boolean) => void;
-    }
+  export interface Location {
+    i: number;
+    j: number;
+  }
+  export interface Selection {
+    start: Location;
+    end: Location;
+  }
+  /** Properties of the ReactDataSheet component. */
+  export interface DataSheetProps<T extends Cell<T, V>, V = string> {
+    /** Optional function to add attributes to the rendered cell element. It should return an object with properties corresponding to the name and vales of the attributes you wish to add. */
+    attributesRenderer?: AttributesRenderer<T, V>;
+    /** Optional function or React Component to render each cell element. The default renders a td element. */
+    cellRenderer?: CellRenderer<T, V>;
+    className?: string;
+    /** Array of rows and each row should contain the cell objects to display. */
+    data: T[][];
+    /** Optional: Avoid Datasheet to listen for clicks on the page */
+    disablePageClick?: boolean;
+    /** Optional function or React Component to render a custom editor. Affects every cell in the sheet. Affects every cell in the sheet. See cell options to override individual cells. */
+    dataEditor?: DataEditor<T, V>;
+    /** Method to render the underlying value of the cell function(cell, i, j). This data is visible once in edit mode. */
+    dataRenderer?: DataRenderer<T, V>;
+    /** Method to handle copying from cell */
+    handleCopy?: HandleCopyFunction<T, V>;
+    /** onCellsChanged handler: function(arrayOfChanges[, arrayOfAdditions]) {}, where changes is an array of objects of the shape {cell, row, col, value}. */
+    onCellsChanged?: CellsChangedHandler<T, V>;
+    /** Context menu handler : function(event, cell, i, j). */
+    onContextMenu?: ContextMenuHandler<T, V>;
+    /** Grid default for how to render overflow text in cells. */
+    overflow?: 'wrap' | 'nowrap' | 'clip';
+    /** Optional function or React Component to render each row element. The default renders a <tr> element. */
+    rowRenderer?: RowRenderer<T, V>;
+    /** If set, the function will be called with the raw clipboard data. It should return an array of arrays of strings. This is useful for when the clipboard may have data with irregular field or line delimiters. If not set, rows will be split with line breaks and cells with tabs. */
+    parsePaste?: PasteParser;
+    /** Optional function or React Component to render the main sheet element. The default renders a table element. */
+    sheetRenderer?: SheetRenderer<T, V>;
+    /** Method to render the value of the cell function(cell, i, j). This is visible by default. */
+    valueRenderer: ValueRenderer<T, V>;
+    /** Optional function or React Component to customize the way the value for each cell in the sheet is displayed. Affects every cell in the sheet. See cell options to override individual cells. */
+    valueViewer?: ValueViewer<T, V>;
+    /** Optional. Passing a selection format will make the selection controlled, pass a null for usual behaviour**/
+    selected?: Selection | null;
+    /** Optional. Calls the function whenever the user changes selection**/
+    onSelect?: (selection: Selection) => void;
+    /** Optional. Function to set row key. **/
+    keyFn?: (row: number) => string | number;
+    /** Optional: Function that can decide whether navigating to the indicated cell is possible. */
+    isCellNavigable?: (
+      cell: T,
+      row: number,
+      col: number,
+      jumpNext: boolean,
+    ) => boolean;
+    /** Optional: Is called when datasheet changes edit mode. */
+    editModeChanged?: (inEditMode: boolean) => void;
+    /** Determines if user can perform a selection without losing focus of edited cell. */
+    canSelectWhileEditing?: boolean;
+    /** Determines if user is performing a selection without losing focus of edited cell. */
+    isSelectingWhileEditing?: boolean;
 
-    /** A function to process the raw clipboard data. It should return an array of arrays of strings. This is useful for when the clipboard may have data with irregular field or line delimiters. If not set, rows will be split with line breaks and cells with tabs. To wire it up pass your function to the parsePaste property of the ReactDataSheet component. */
-    export type PasteParser = (pastedString: string) => string[][];
+    onSelectWhileEditingStart?: () => void;
 
-    /** A function to render the value of the cell function(cell, i, j). This is visible by default. To wire it up, pass your function to the valueRenderer property of the ReactDataSheet component. */
-    export type ValueRenderer<T extends Cell<T, V>, V = string> = (cell: T, row: number, col: number) => string | number | null | void;
+    onSelectWhileEditingComplete?: () => void;
 
-    /** A function to render the underlying value of the cell. This data is visible once in edit mode.  To wire it up, pass your function to the dataRenderer property of the ReactDataSheet component. */
-    export type DataRenderer<T extends Cell<T, V>, V = string> = (cell: T, row: number, col: number) => string | number | null | void;
+    onSelectWhileEditingAbort?: () => void;
+  }
 
-    /** A function to add attributes to the rendered cell element. It should return an object with properties corresponding to the name and vales of the attributes you wish to add. To wire it up, pass your function to the attributesRenderer property of the ReactDataSheet component. */
-    export type AttributesRenderer<T extends Cell<T, V>, V = string> = (cell: T, row: number, col: number) => {};
+  /** A function to process the raw clipboard data. It should return an array of arrays of strings. This is useful for when the clipboard may have data with irregular field or line delimiters. If not set, rows will be split with line breaks and cells with tabs. To wire it up pass your function to the parsePaste property of the ReactDataSheet component. */
+  export type PasteParser = (pastedString: string) => string[][];
 
-    /** The properties that will be passed to the SheetRenderer component or function. */
-    export interface SheetRendererProps<T extends Cell<T, V>, V = string> {
-        /** The same data array as from main ReactDataSheet component */
-        data: T[][];
-        /** Classes to apply to your top-level element. You can add to these, but your should not overwrite or omit them unless you want to implement your own CSS also. */
-        className: string;
-        /** The regular react props.children. You must render {props.children} within your custom renderer or you won't see your rows and cells. */
-        children: ReactNode;
-    }
+  /** A function to render the value of the cell function(cell, i, j). This is visible by default. To wire it up, pass your function to the valueRenderer property of the ReactDataSheet component. */
+  export type ValueRenderer<T extends Cell<T, V>, V = string> = (
+    cell: T,
+    row: number,
+    col: number,
+  ) => string | number | null | void;
 
-    /** Optional function or React Component to render the main sheet element. The default renders a table element. To wire it up, pass your function to the sheetRenderer property of the ReactDataSheet component. */
-    export type SheetRenderer<T extends Cell<T, V>, V = string> = React.ComponentClass<SheetRendererProps<T, V>> | React.SFC<SheetRendererProps<T, V>>;
+  /** A function to render the underlying value of the cell. This data is visible once in edit mode.  To wire it up, pass your function to the dataRenderer property of the ReactDataSheet component. */
+  export type DataRenderer<T extends Cell<T, V>, V = string> = (
+    cell: T,
+    row: number,
+    col: number,
+  ) => string | number | null | void;
 
-    /** The properties that will be passed to the RowRenderer component or function. */
-    export interface RowRendererProps<T extends Cell<T, V>, V = string> {
-        /** The current row index */
-        row: number;
-        /** The cells in the current row */
-        cells: T[];
-        /** The regular react props.children. You must render {props.children} within your custom renderer or you won't see your cells. */
-        children: ReactNode;
-    }
+  /** A function to add attributes to the rendered cell element. It should return an object with properties corresponding to the name and vales of the attributes you wish to add. To wire it up, pass your function to the attributesRenderer property of the ReactDataSheet component. */
+  export type AttributesRenderer<T extends Cell<T, V>, V = string> = (
+    cell: T,
+    row: number,
+    col: number,
+  ) => {};
 
-    /** Optional function or React Component to render each row element. The default renders a tr element. To wire it up, pass your function to the rowRenderer property of the ReactDataSheet component. */
-    export type RowRenderer<T extends Cell<T, V>, V = string> = React.ComponentClass<RowRendererProps<T, V>> | React.SFC<RowRendererProps<T, V>>;
+  /** The properties that will be passed to the SheetRenderer component or function. */
+  export interface SheetRendererProps<T extends Cell<T, V>, V = string> {
+    /** The same data array as from main ReactDataSheet component */
+    data: T[][];
+    /** Classes to apply to your top-level element. You can add to these, but your should not overwrite or omit them unless you want to implement your own CSS also. */
+    className: string;
+    /** The regular react props.children. You must render {props.children} within your custom renderer or you won't see your rows and cells. */
+    children: ReactNode;
+  }
 
-    /** The arguments that will be passed to the first parameter of the onCellsChanged handler function. These represent all the changes _inside_ the bounds of the existing grid. The first generic parameter (required) indicates the type of the cell property, and the second generic parameter (default: string) indicates the type of the value property. */
-    export type CellsChangedArgs<T extends Cell<T, V>, V = string> = {
-        /** the original cell object you provided in the data property. This may be null */
-        cell: T | null;
-        /** row index of changed cell */
-        row: number;
-        /** column index of changed cell */
-        col: number;
-        /** The new cell value. This is usually a string, but a custom editor may provide any type of value. */
-        value: V | null;
-    }[];
+  /** Optional function or React Component to render the main sheet element. The default renders a table element. To wire it up, pass your function to the sheetRenderer property of the ReactDataSheet component. */
+  export type SheetRenderer<T extends Cell<T, V>, V = string> =
+    | React.ComponentClass<SheetRendererProps<T, V>>
+    | React.SFC<SheetRendererProps<T, V>>;
 
-    /** The arguments that will be passed to the second parameter of the onCellsChanged handler function. These represent all the changes _outside_ the bounds of the existing grid. The  generic parameter (default: string) indicates the type of the value property. */
-    export type CellAdditionsArgs<V = string> = {
-        row: number;
-        col: number;
-        value: V | null;
-    }[];
+  /** The properties that will be passed to the RowRenderer component or function. */
+  export interface RowRendererProps<T extends Cell<T, V>, V = string> {
+    /** The current row index */
+    row: number;
+    /** The cells in the current row */
+    cells: T[];
+    /** The regular react props.children. You must render {props.children} within your custom renderer or you won't see your cells. */
+    children: ReactNode;
+  }
 
-    /** onCellsChanged handler: function(arrayOfChanges[, arrayOfAdditions]) {}, where changes is an array of objects of the shape {cell, row, col, value}. To wire it up, pass your function to the onCellsChanged property of the ReactDataSheet component. */
-    export type CellsChangedHandler<T extends Cell<T, V>, V = string> = (arrayOfChanges: CellsChangedArgs<T, V>, arrayOfAdditions?: CellAdditionsArgs<V>) => void;
+  /** Optional function or React Component to render each row element. The default renders a tr element. To wire it up, pass your function to the rowRenderer property of the ReactDataSheet component. */
+  export type RowRenderer<T extends Cell<T, V>, V = string> =
+    | React.ComponentClass<RowRendererProps<T, V>>
+    | React.SFC<RowRendererProps<T, V>>;
 
-    /** Context menu handler : function(event, cell, i, j). To wire it up, pass your function to the onContextMenu property of the ReactDataSheet component. */
-    export type ContextMenuHandler<T extends Cell<T, V>, V = string> = (event: MouseEvent, cell: T, row : number, col: number) => void;
+  /** The arguments that will be passed to the first parameter of the onCellsChanged handler function. These represent all the changes _inside_ the bounds of the existing grid. The first generic parameter (required) indicates the type of the cell property, and the second generic parameter (default: string) indicates the type of the value property. */
+  export type CellsChangedArgs<T extends Cell<T, V>, V = string> = {
+    /** the original cell object you provided in the data property. This may be null */
+    cell: T | null;
+    /** row index of changed cell */
+    row: number;
+    /** column index of changed cell */
+    col: number;
+    /** The new cell value. This is usually a string, but a custom editor may provide any type of value. */
+    value: V | null;
+  }[];
 
-    /* Props available for handleCopy */
-    export interface HandleCopyProps<T extends Cell<T, V>, V = string> {
-        event: Event;
-        dataRenderer: DataRenderer<T, V>;
-        valueRenderer: ValueRenderer<T, V>;
-        data: T[][];
-        start: Location;
-        end: Location;
-        range: (start: number, end: number) => [];
-    }
+  /** The arguments that will be passed to the second parameter of the onCellsChanged handler function. These represent all the changes _outside_ the bounds of the existing grid. The  generic parameter (default: string) indicates the type of the value property. */
+  export type CellAdditionsArgs<V = string> = {
+    row: number;
+    col: number;
+    value: V | null;
+  }[];
 
-    export type HandleCopyFunction<T extends Cell<T, V>, V = string> = (props: HandleCopyProps<T, V>) => void;
+  /** onCellsChanged handler: function(arrayOfChanges[, arrayOfAdditions]) {}, where changes is an array of objects of the shape {cell, row, col, value}. To wire it up, pass your function to the onCellsChanged property of the ReactDataSheet component. */
+  export type CellsChangedHandler<T extends Cell<T, V>, V = string> = (
+    arrayOfChanges: CellsChangedArgs<T, V>,
+    arrayOfAdditions?: CellAdditionsArgs<V>,
+  ) => void;
 
-    /** The properties that will be passed to the CellRenderer component or function. */
-    export interface CellRendererProps<T extends Cell<T, V>, V = string> {
-        /** The current row index */
-        row: number;
-        /** The current column index */
-        col: number;
-        /** The cell's raw data structure */
-        cell: T;
-        /** Classes to apply to your cell element. You can add to these, but your should not overwrite or omit them unless you want to implement your own CSS also. */
-        className: string;
-        /** Generated styles that you should apply to your cell element. This may be null or undefined. */
-        style: object | null | undefined;
-        /** Is the cell currently selected */
-        selected: boolean;
-        /** Is the cell currently being edited */
-        editing: boolean;
-        /** Was the cell recently updated */
-        updated: boolean;
-        /** As for the main ReactDataSheet component */
-        attributesRenderer: AttributesRenderer<T, V>;
-        /** Event handler: important for cell selection behavior */
-        onMouseDown: MouseEventHandler<HTMLElement>;
-        /** Event handler: important for cell selection behavior */
-        onMouseOver: MouseEventHandler<HTMLElement>;
-        /** Event handler: important for editing */
-        onDoubleClick: MouseEventHandler<HTMLElement>;
-        /** Event handler: to launch default content-menu handling. You can safely ignore this handler if you want to provide your own content menu handling. */
-        onContextMenu: MouseEventHandler<HTMLElement>;
-        /** Event handler: important for cell selection behavior */
-        onKeyUp: KeyboardEventHandler<HTMLElement>;
-        /** The regular react props.children. You must render {props.children} within your custom renderer or you won't your cell's data. */
-        children: ReactNode;
-    }
+  /** Context menu handler : function(event, cell, i, j). To wire it up, pass your function to the onContextMenu property of the ReactDataSheet component. */
+  export type ContextMenuHandler<T extends Cell<T, V>, V = string> = (
+    event: MouseEvent,
+    cell: T,
+    row: number,
+    col: number,
+  ) => void;
 
-    /** A function or React Component to render each cell element. The default renders a td element. To wire it up, pass it to the cellRenderer property of the ReactDataSheet component.  */
-    export type CellRenderer<T extends Cell<T, V>, V = string> = React.ComponentClass<CellRendererProps<T, V>> | React.SFC<CellRendererProps<T, V>>;
+  /* Props available for handleCopy */
+  export interface HandleCopyProps<T extends Cell<T, V>, V = string> {
+    event: Event;
+    dataRenderer: DataRenderer<T, V>;
+    valueRenderer: ValueRenderer<T, V>;
+    data: T[][];
+    start: Location;
+    end: Location;
+    range: (start: number, end: number) => [];
+  }
 
-    /** The properties that will be passed to the CellRenderer component or function. */
-    export interface ValueViewerProps<T extends Cell<T, V>, V = string> {
-        /** The result of the valueRenderer function */
-        value: string | number | null;
-        /** The current row index */
-        row: number;
-        /** The current column index */
-        col: number;    
-        /** The cell's raw data structure */
-        cell: T;
-    }
+  export type HandleCopyFunction<T extends Cell<T, V>, V = string> = (
+    props: HandleCopyProps<T, V>,
+  ) => void;
 
-    /** Optional function or React Component to customize the way the value for each cell in the sheet is displayed. If it is passed to the valueViewer property of the ReactDataSheet component, it affects every cell in the sheet. Different editors can also be passed to the valueViewer property of each Cell to control each cell separately. */
-    export type ValueViewer<T extends Cell<T, V>, V = string> = React.ComponentClass<ValueViewerProps<T, V>> | React.SFC<ValueViewerProps<T, V>>;
+  /** The properties that will be passed to the CellRenderer component or function. */
+  export interface CellRendererProps<T extends Cell<T, V>, V = string> {
+    /** The current row index */
+    row: number;
+    /** The current column index */
+    col: number;
+    /** The cell's raw data structure */
+    cell: T;
+    /** Classes to apply to your cell element. You can add to these, but your should not overwrite or omit them unless you want to implement your own CSS also. */
+    className: string;
+    /** Generated styles that you should apply to your cell element. This may be null or undefined. */
+    style: object | null | undefined;
+    /** Is the cell currently selected */
+    selected: boolean;
+    /** Is the cell currently being edited */
+    editing: boolean;
+    /** Was the cell recently updated */
+    updated: boolean;
+    /** As for the main ReactDataSheet component */
+    attributesRenderer: AttributesRenderer<T, V>;
+    /** Event handler: important for cell selection behavior */
+    onMouseDown: MouseEventHandler<HTMLElement>;
+    /** Event handler: important for cell selection behavior */
+    onMouseOver: MouseEventHandler<HTMLElement>;
+    /** Event handler: important for editing */
+    onDoubleClick: MouseEventHandler<HTMLElement>;
+    /** Event handler: to launch default content-menu handling. You can safely ignore this handler if you want to provide your own content menu handling. */
+    onContextMenu: MouseEventHandler<HTMLElement>;
+    /** Event handler: important for cell selection behavior */
+    onKeyUp: KeyboardEventHandler<HTMLElement>;
+    /** The regular react props.children. You must render {props.children} within your custom renderer or you won't your cell's data. */
+    children: ReactNode;
+  }
 
-    /** The properties that will be passed to the DataEditor component or function. */
-    export interface DataEditorProps<T, V = string> {
-        /** The result of the dataRenderer (or valueRenderer if none) */
-        value: string | number | null;
-        /** The current row index */
-        row: number;
-        /** The current column index */
-        col: number;
-        /** The cell's raw data structure */
-        cell: T;
-        /** A callback for when the user changes the value during editing (for example, each time they type a character into an input). onChange does not indicate the final edited value. It works just like a controlled component in a form. */
-        onChange: (newValue: V) => void;
-        /** An event handler that you can call to use default React-DataSheet keyboard handling to signal reverting an ongoing edit (Escape key) or completing an edit (Enter or Tab). For most editors based on an input element this will probably work. However, if this keyboard handling is unsuitable for your editor you can trigger these changes explicitly using the onCommit and onRevert callbacks. */
-        onKeyDown: React.KeyboardEventHandler<HTMLElement>;
-        /** function (newValue, [event]) {} A callback to indicate that editing is over, here is the final value. If you pass a KeyboardEvent as the second argument, React-DataSheet will perform default navigation for you (for example, going down to the next row if you hit the enter key). You actually don't need to use onCommit if the default keyboard handling is good enough for you. */
-        onCommit: (newValue: V, event?: React.KeyboardEvent<HTMLElement>) => void;
-        /** function () {} A no-args callback that you can use to indicate that you want to cancel ongoing edits. As with onCommit, you don't need to worry about this if the default keyboard handling works for your editor. */
-        onRevert: () => void;
-    }
+  /** A function or React Component to render each cell element. The default renders a td element. To wire it up, pass it to the cellRenderer property of the ReactDataSheet component.  */
+  export type CellRenderer<T extends Cell<T, V>, V = string> =
+    | React.ComponentClass<CellRendererProps<T, V>>
+    | React.SFC<CellRendererProps<T, V>>;
 
-    /** A function or React Component to render a custom editor. If it is passed to the dataEditor property of the ReactDataSheet component, it affects every cell in the sheet. Different editors can also be passed to the dataEditor property of each Cell to control each cell separately. */
-    export type DataEditor<T extends Cell<T, V>, V = string> = React.ComponentClass<DataEditorProps<T, V>> | React.SFC<DataEditorProps<T, V>>;
+  /** The properties that will be passed to the CellRenderer component or function. */
+  export interface ValueViewerProps<T extends Cell<T, V>, V = string> {
+    /** The result of the valueRenderer function */
+    value: string | number | null;
+    /** The current row index */
+    row: number;
+    /** The current column index */
+    col: number;
+    /** The cell's raw data structure */
+    cell: T;
+  }
 
-    export interface CellReference {
-        row: number;
-        col: number;
-    }
+  /** Optional function or React Component to customize the way the value for each cell in the sheet is displayed. If it is passed to the valueViewer property of the ReactDataSheet component, it affects every cell in the sheet. Different editors can also be passed to the valueViewer property of each Cell to control each cell separately. */
+  export type ValueViewer<T extends Cell<T, V>, V = string> =
+    | React.ComponentClass<ValueViewerProps<T, V>>
+    | React.SFC<ValueViewerProps<T, V>>;
 
-    export interface DataSheetState {
-        start?: CellReference;
-        end?: CellReference;
-        selecting?: boolean;
-        forceEdit?: boolean;
-        editing?: CellReference;
-        clear?: CellReference;
-    }
+  /** The properties that will be passed to the DataEditor component or function. */
+  export interface DataEditorProps<T, V = string> {
+    /** The result of the dataRenderer (or valueRenderer if none) */
+    value: string | number | null;
+    /** The current row index */
+    row: number;
+    /** The current column index */
+    col: number;
+    /** The cell's raw data structure */
+    cell: T;
+    /** A callback for when the user changes the value during editing (for example, each time they type a character into an input). onChange does not indicate the final edited value. It works just like a controlled component in a form. */
+    onChange: (newValue: V) => void;
+    /** An event handler that you can call to use default React-DataSheet keyboard handling to signal reverting an ongoing edit (Escape key) or completing an edit (Enter or Tab). For most editors based on an input element this will probably work. However, if this keyboard handling is unsuitable for your editor you can trigger these changes explicitly using the onCommit and onRevert callbacks. */
+    onKeyDown: React.KeyboardEventHandler<HTMLElement>;
+    /** function (newValue, [event]) {} A callback to indicate that editing is over, here is the final value. If you pass a KeyboardEvent as the second argument, React-DataSheet will perform default navigation for you (for example, going down to the next row if you hit the enter key). You actually don't need to use onCommit if the default keyboard handling is good enough for you. */
+    onCommit: (newValue: V, event?: React.KeyboardEvent<HTMLElement>) => void;
+    /** function () {} A no-args callback that you can use to indicate that you want to cancel ongoing edits. As with onCommit, you don't need to worry about this if the default keyboard handling works for your editor. */
+    onRevert: () => void;
+  }
+
+  /** A function or React Component to render a custom editor. If it is passed to the dataEditor property of the ReactDataSheet component, it affects every cell in the sheet. Different editors can also be passed to the dataEditor property of each Cell to control each cell separately. */
+  export type DataEditor<T extends Cell<T, V>, V = string> =
+    | React.ComponentClass<DataEditorProps<T, V>>
+    | React.SFC<DataEditorProps<T, V>>;
+
+  export interface CellReference {
+    row: number;
+    col: number;
+  }
+
+  export interface DataSheetState {
+    start?: CellReference;
+    end?: CellReference;
+    selecting?: boolean;
+    forceEdit?: boolean;
+    editing?: CellReference;
+    clear?: CellReference;
+    dragging?: boolean;
+  }
 }
 
-declare class ReactDataSheet<T extends ReactDataSheet.Cell<T, V>, V = string> extends Component<ReactDataSheet.DataSheetProps<T, V>, ReactDataSheet.DataSheetState> {
-        getSelectedCells: (data: T[][], start: ReactDataSheet.CellReference, end: ReactDataSheet.CellReference) => {cell: T, row: number, col: number}[];
+declare class ReactDataSheet<
+  T extends ReactDataSheet.Cell<T, V>,
+  V = string,
+> extends Component<
+  ReactDataSheet.DataSheetProps<T, V>,
+  ReactDataSheet.DataSheetState
+> {
+  getSelectedCells: (
+    data: T[][],
+    start: ReactDataSheet.CellReference,
+    end: ReactDataSheet.CellReference,
+  ) => { cell: T; row: number; col: number }[];
+  onMouseOver(i: number, j: number): void;
+  handleCut(e: ClipboardEvent): void;
+  handleCopy(e: ClipboardEvent): void;
+  handlePaste(e: ClipboardEvent): void;
 }
 
 export default ReactDataSheet;


### PR DESCRIPTION
Implemented ability to reference other cells while editing the other one.

What has been done:
- Added prop `canSelectWhileEditing`, which indicates that another cell can be referenced when clicking. Library users can perform ant check in outer code and just pass this boolean flag;
- Added prop `isSelectingWhileEditing`, which indicates that user is currently editing one cell and referencing other ones. This flag is used to process new use-cases inside event handlers (e.g. mouse/keyboard events);
- Added callbacks `onSelectWhileEditingStart`, `onSelectWhileEditingComplete`, `onSelectWhileEditingAbort` - they form some sort of "lifecycle" for selecting other cells;

Also added typing for some code from other tasks, to make application cleaner.