### PR TITLE
Add re-renders back to handle editing initiated with text input

### DIFF
--- a/lib/DataCell.js
+++ b/lib/DataCell.js
@@ -325,7 +325,7 @@ var DataCell = (function (_PureComponent) {
             cell: cell,
             row: row,
             col: col,
-            value: this.state.value || initialData(this.props),
+            value: this.state.value,
             onChange: this.handleChange,
             onCommit: this.handleCommit,
             onRevert: this.handleRevert,

--- a/src/DataCell.js
+++ b/src/DataCell.js
@@ -165,7 +165,7 @@ export default class DataCell extends PureComponent {
           cell={cell}
           row={row}
           col={col}
-          value={this.state.value || initialData(this.props)}
+          value={this.state.value}
           onChange={this.handleChange}
           onCommit={this.handleCommit}
           onRevert={this.handleRevert}


### PR DESCRIPTION
It seems that we needed this re-render to initiate edit mode by overriding the new text.